### PR TITLE
Create metabrowse-server module to serve sources on-demand

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,0 +1,7 @@
+-Xss4m
+-Xms1G
+-Xmx4G
+-XX:ReservedCodeCacheSize=1024m
+-XX:+TieredCompilation
+-XX:+CMSClassUnloadingEnabled
+-Dfile.encoding=UTF-8

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ jobs:
   include:
     - env: TEST="sbt ci-test"
       script: sbt ci-test
+    - jdk: openjdk11
+      env: TEST="sbt ci-test"
+      script: sbt ci-test
     - env: TEST="sbt ci-test"
       scala: 2.11.12
       script: sbt ci-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,9 @@ jobs:
   include:
     - env: TEST="sbt ci-test"
       script: sbt ci-test
-    # Disabled until mtags dependency of server is published for 2.11
-    # - env: TEST="sbt ci-test"
-    #   scala: 2.11.12
-    #   script: sbt ci-test
+    - env: TEST="sbt ci-test"
+      scala: 2.11.12
+      script: sbt ci-test
     - env: TEST="sbt scripted"
       script: sbt scripted
     - env: TEST=scalafmt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: scala
-scala: 2.12.6
+scala: 2.12.7
 jdk: oraclejdk8
 sudo: false
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,10 @@ jobs:
   include:
     - env: TEST="sbt ci-test"
       script: sbt ci-test
-    - env: TEST="sbt ci-test"
-      scala: 2.11.12
-      script: sbt ci-test
+    # Disabled until mtags dependency of server is published for 2.11
+    # - env: TEST="sbt ci-test"
+    #   scala: 2.11.12
+    #   script: sbt ci-test
     - env: TEST="sbt scripted"
       script: sbt scripted
     - env: TEST=scalafmt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+version: '{build}'
+os: Windows Server 2012
+install:
+  - cmd: SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
+  - cmd: SET PATH=%JAVA_HOME%\bin;%PATH%
+  - cmd: choco install sbt -ia "INSTALLDIR=""C:\sbt"""
+  - cmd: SET PATH=C:\sbt\bin;%JAVA_HOME%\bin;%PATH%
+  - cmd: SET SBT_OPTS=-XX:MaxPermSize=2g -Xmx4g
+environment:
+  APPVEYOR_CACHE_ENTRY_ZIP_ARGS: "-t7z -m0=lzma -mx=9"
+build_script:
+  - sbt compile
+test_script:
+  - sbt metabrowse-site test
+cache:
+  - C:\sbt\
+  - C:\Users\appveyor\.ivy2
+  - C:\Users\appveyor\.coursier
+  - C:\Users\appveyor\.cache
+  - C:\Users\appveyor\.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,7 @@ lazy val server = project
   .in(file("metabrowse-server"))
   .settings(
     moduleName := "metabrowse-server",
+    resolvers += Resolver.sonatypeRepo("releases"),
     resolvers += Resolver.sonatypeRepo("snapshots"),
     libraryDependencies ++= List(
       "io.undertow" % "undertow-core" % "2.0.13.Final",

--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,7 @@ lazy val server = project
       "org.slf4j" % "slf4j-simple" % "1.8.0-beta2",
       "org.jboss.xnio" % "xnio-nio" % "3.6.5.Final",
       "org.scalameta" % "interactive" % "4.0.0" cross CrossVersion.full,
-      "org.scalameta" %% "mtags" % "0.2.0-M1"
+      "org.scalameta" %% "mtags" % "0.2.0"
     )
   )
   .dependsOn(cli)

--- a/build.sbt
+++ b/build.sbt
@@ -263,4 +263,10 @@ lazy val tests = project
   .dependsOn(cli, server)
   .enablePlugins(BuildInfoPlugin)
 
-addCommandAlias("ci-test", ";compile ; metabrowse-site ; test")
+commands += Command.command("ci-test") { s =>
+  s"++${sys.env("TRAVIS_SCALA_VERSION")}" ::
+    "compile" ::
+    "metabrowse-site" ::
+    "test" ::
+    s
+}

--- a/metabrowse-cli/src/main/scala/metabrowse/cli/FingerprintOps.scala
+++ b/metabrowse-cli/src/main/scala/metabrowse/cli/FingerprintOps.scala
@@ -3,7 +3,6 @@ package metabrowse.cli
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
-import javax.xml.bind.DatatypeConverter
 
 object FingerprintOps {
 
@@ -14,7 +13,20 @@ object FingerprintOps {
   def md5(buffer: ByteBuffer): String = {
     val md = MessageDigest.getInstance("MD5")
     md.update(buffer)
-    DatatypeConverter.printHexBinary(md.digest())
+    bytesToHex(md.digest())
+  }
+
+  private val hexArray = "0123456789ABCDEF".toCharArray
+  def bytesToHex(bytes: Array[Byte]): String = {
+    val hexChars = new Array[Char](bytes.length * 2)
+    var j = 0
+    while (j < bytes.length) {
+      val v: Int = bytes(j) & 0xFF
+      hexChars(j * 2) = hexArray(v >>> 4)
+      hexChars(j * 2 + 1) = hexArray(v & 0x0F)
+      j += 1
+    }
+    new String(hexChars)
   }
 
 }

--- a/metabrowse-js/src/main/scala/metabrowse/MetabrowseFetch.scala
+++ b/metabrowse-js/src/main/scala/metabrowse/MetabrowseFetch.scala
@@ -6,13 +6,16 @@ import scala.meta.internal.{semanticdb => s}
 import metabrowse.MetabrowseApp._
 import metabrowse.{schema => d}
 import MetabrowseEnrichments._
+import org.scalajs.dom.experimental.Headers
 
 object MetabrowseFetch {
 
   def symbol(symbolId: String): Future[Option[d.SymbolIndex]] = {
     val url = "symbol/" + symbolId.symbolIndexPath
+    val headers = new Headers()
+    headers.set("Metabrowse-Symbol", symbolId)
     for {
-      bytes <- fetchBytes(url)
+      bytes <- fetchBytes(url, headers)
     } yield {
       val indexes = d.SymbolIndexes.parseFrom(bytes)
       indexes.indexes.find(_.symbol == symbolId)

--- a/metabrowse-js/src/test/scala/metabrowse/PakoSuite.scala
+++ b/metabrowse-js/src/test/scala/metabrowse/PakoSuite.scala
@@ -26,7 +26,7 @@ class PakoSuite extends FunSuite {
     TypedArrayBuffer.wrap(output).get(out)
     val workspace = Workspace.parseFrom(out)
     val obtained =
-      workspace.toProtoString.lines.toList.sorted.mkString("\n").trim
+      workspace.toProtoString.linesIterator.toList.sorted.mkString("\n").trim
     val expected =
       """
         |filenames: "paiges/core/src/main/scala/org/typelevel/paiges/Chunk.scala"

--- a/metabrowse-server/src/main/scala/metabrowse/server/MetabrowseServer.scala
+++ b/metabrowse-server/src/main/scala/metabrowse/server/MetabrowseServer.scala
@@ -1,0 +1,378 @@
+package metabrowse.server
+
+import io.undertow.Undertow
+import io.undertow.server.HttpHandler
+import io.undertow.server.HttpServerExchange
+import io.undertow.util.Headers
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.net.URLClassLoader
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Scanner
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import java.util.zip.GZIPOutputStream
+import metabrowse.schema.SymbolIndex
+import metabrowse.schema.SymbolIndexes
+import metabrowse.schema.Workspace
+import metabrowse.{schema => d}
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import scala.collection.mutable.ArrayBuffer
+import scala.meta.inputs.Input
+import scala.meta.interactive.InteractiveSemanticdb
+import scala.meta.internal.io.FileIO
+import scala.meta.internal.io.InputStreamIO
+import scala.meta.internal.mtags.Enrichments._
+import scala.meta.internal.mtags.Mtags
+import scala.meta.internal.mtags.OnDemandSymbolIndex
+import scala.meta.internal.semanticdb.TextDocuments
+import scala.meta.internal.semanticdb.scalac.SemanticdbOps
+import scala.meta.internal.{mtags => t}
+import scala.meta.io.AbsolutePath
+import scala.tools.nsc.interactive.Global
+import scala.util.control.NonFatal
+
+class MetabrowseServer(
+    scalacOptions: List[String] = Nil,
+    host: String = "localhost",
+    port: Int = 4000,
+    logger: Logger = LoggerFactory.getLogger("MetabrowseServer")
+) {
+
+  /** Starts a server that servers sources from the sourcepath. */
+  def start(sourcepath: Sourcepath): Unit = {
+    replaceClasspath(sourcepath)
+    server.start()
+  }
+
+  /** Stops the server and cleans up internal state */
+  def stop(): Unit = {
+    server.stop()
+    global.askShutdown()
+  }
+
+  /** Updates the running server to use a new sourcepath.
+    *
+    * Browser clients need to refresh their browser to pick up the new state.
+    *
+    * Beware: this method is untested!
+    */
+  def replaceClasspath(sourcepath: Sourcepath): Unit = {
+    lock.synchronized {
+      if (state.get() != null) {
+        global.askShutdown()
+      }
+      val newState = State(
+        OnDemandSymbolIndex(),
+        new URLClassLoader(sourcepath.sources.map(_.toUri.toURL).toArray),
+        InteractiveSemanticdb.newCompiler(
+          sourcepath.classpath.mkString(File.pathSeparator),
+          scalacOptions
+        ),
+        sourcepath
+      )
+      state.set(newState)
+      sourcepath.sources.foreach(jar => index.addSourceJar(AbsolutePath(jar)))
+    }
+  }
+
+  /** Returns the URL path pointing to the definition location of the given symbol */
+  def urlForSymbol(
+      compiler: Global
+  )(symbol: compiler.Symbol): Option[String] = {
+    lazy val semanticdbOps: SemanticdbOps {
+      val global: compiler.type
+    } = new SemanticdbOps {
+      val global: compiler.type = compiler
+    }
+    import semanticdbOps._
+    var compilerSymbol: compiler.Symbol = compiler.rootMirror.RootPackage
+    symbol.ownerChain.reverse.drop(1).foreach { owner =>
+      val name =
+        if (owner.name.isTermName || owner.hasPackageFlag) {
+          compiler.TermName(owner.nameString)
+        } else {
+          compiler.TypeName(owner.nameString)
+        }
+      compilerSymbol = compilerSymbol.info.member(name)
+    }
+    val semanticdbSymbol = compilerSymbol.toSemantic
+    for {
+      symbolIndex <- getSymbol(semanticdbSymbol).indexes.headOption
+      position <- symbolIndex.definition
+    } yield {
+      s"#${position.filename}#L${position.startLine}C${position.startCharacter}"
+    }
+  }
+
+  // Mutable state:
+  case class State(
+      index: OnDemandSymbolIndex,
+      classLoader: URLClassLoader,
+      global: Global,
+      sourcepath: Sourcepath
+  )
+  private val state = new AtomicReference[State]()
+  def index = state.get().index
+  def classLoader = state.get().classLoader
+  def global = state.get().global
+  def sourcepath = state.get().sourcepath
+
+  // Static state:
+  private val lock = new Object()
+  private val assets = {
+    val in =
+      this.getClass.getClassLoader.getResourceAsStream("metabrowse-assets.zip")
+    val out = Files.createTempDirectory("metabrowse").resolve("assets.zip")
+    Files.copy(in, out)
+    FileIO.jarRootPath(AbsolutePath(out))
+  }
+  private val httpHandler = new HttpHandler {
+    override def handleRequest(exchange: HttpServerExchange): Unit = {
+      val bytes =
+        try {
+          lock.synchronized {
+            getBytes(exchange)
+          }
+        } catch {
+          case NonFatal(e) =>
+            logger.error(s"unexpected error: $exchange", e)
+            Array.emptyByteArray
+        }
+      val compressed = gzipDeflate(bytes)
+      val buffer = ByteBuffer.wrap(compressed)
+      exchange.getResponseHeaders.put(
+        Headers.CONTENT_ENCODING,
+        "gzip"
+      )
+      exchange.getResponseHeaders.put(
+        Headers.CONTENT_TYPE,
+        contentType(exchange.getRequestPath)
+      )
+      exchange.getResponseSender.send(buffer)
+    }
+  }
+  private val server = Undertow
+    .builder()
+    .addHttpListener(port, host)
+    .setHandler(httpHandler)
+    .build()
+
+  private def getBytes(exchange: HttpServerExchange): Array[Byte] = {
+    val path = exchange.getRequestPath.stripSuffix(".gz")
+    if (path.endsWith("index.workspace")) {
+      getWorkspace.toByteArray
+    } else if (path.endsWith(".symbolindexes")) {
+      val header = exchange.getRequestHeaders.get("Metabrowse-Symbol")
+      if (header.isEmpty) {
+        logger.error(s"no Metabrowse-Symbol header: $exchange")
+        Array.emptyByteArray
+      } else {
+        getSymbol(header.getFirst).toByteArray
+      }
+    } else if (path.endsWith(".semanticdb")) {
+      getSemanticdb(path).toByteArray
+    } else if (path.endsWith(".map")) {
+      // Ignore requests for sourcemaps.
+      Array.emptyByteArray
+    } else {
+      val actualPath = if (path == "/") "/index.html" else path
+      val file = assets.resolve(actualPath)
+      if (file.isFile) file.readAllBytes
+      else {
+        logger.warn(s"no such file: $file")
+        Array.emptyByteArray
+      }
+    }
+  }
+
+  private def gzipDeflate(bytes: Array[Byte]): Array[Byte] = {
+    if (bytes.isEmpty) bytes
+    else {
+      val baos = new ByteArrayOutputStream()
+      val gos = new GZIPOutputStream(baos, bytes.length)
+      try {
+        gos.write(bytes)
+        gos.finish()
+        baos.toByteArray
+      } finally {
+        gos.close()
+      }
+    }
+  }
+
+  private def getWorkspace: Workspace = {
+    val filenames = ArrayBuffer.newBuilder[String]
+    for {
+      sourcesJar <- sourcepath.sources
+    } {
+      FileIO.withJarFileSystem(
+        AbsolutePath(sourcesJar),
+        create = false,
+        close = false
+      ) { root =>
+        FileIO
+          .listAllFilesRecursively(root)
+          .filter(!_.toLanguage.isUnknownLanguage)
+          .foreach(path => filenames += path.toNIO.toString.stripPrefix("/"))
+      }
+    }
+    Workspace(filenames.result())
+  }
+
+  private def getSemanticdb(filename: String): TextDocuments = {
+    val path = filename
+      .stripPrefix("/semanticdb/")
+      .stripPrefix("/") // optional '/'
+      .stripSuffix(".semanticdb")
+    logger.info(path)
+    for {
+      in <- Option(classLoader.getResourceAsStream(path)).orElse {
+        logger.warn(s"no source file: $path")
+        None
+      }
+      text = new String(InputStreamIO.readBytes(in), StandardCharsets.UTF_8)
+      doc <- try {
+        val timeout = TimeUnit.SECONDS.toMillis(10)
+        val textDocument = if (path.endsWith(".java")) {
+          val input = Input.VirtualFile(path, text)
+          Mtags.index(input)
+        } else {
+          InteractiveSemanticdb.toTextDocument(
+            global,
+            text,
+            filename,
+            timeout,
+            List("-P:semanticdb:symbols:none")
+          )
+        }
+        Some(textDocument)
+      } catch {
+        case NonFatal(e) =>
+          logger.error(s"compile error: $filename", e)
+          None
+      }
+    } yield TextDocuments(List(doc.withText(text)))
+  }.getOrElse(TextDocuments())
+
+  private def getSymbol(sym: String): SymbolIndexes = {
+    val definition =
+      for {
+        defn <- index
+          .definition(t.Symbol(sym))
+          .orElse {
+            logger.error(s"no definition for symbol: '$sym'")
+            None
+          }
+        input = defn.path.toInput
+        doc = Mtags.index(input)
+        occ <- doc.occurrences
+          .find { occ =>
+            occ.role.isDefinition &&
+            occ.range.isDefined &&
+            occ.symbol == defn.definitionSymbol.value
+          }
+          .orElse {
+            logger.error(s"no definition occurrence: $defn")
+            None
+          }
+        range <- occ.range.orElse {
+          logger.error(s"no range: $occ")
+          None
+        }
+      } yield {
+        d.Position(
+          defn.path.toString(),
+          startLine = range.startLine,
+          startCharacter = range.startCharacter,
+          endLine = range.endLine,
+          endCharacter = range.endCharacter
+        )
+      }
+    SymbolIndexes(
+      List(
+        SymbolIndex(
+          symbol = sym,
+          definition = definition
+        )
+      )
+    )
+  }
+
+  private def contentType(path: String): String = {
+    if (path.endsWith(".js")) "application/javascript"
+    else if (path.endsWith(".css")) "text/css"
+    else if (path.endsWith(".html")) "text/html"
+    else ""
+  }
+}
+
+object MetabrowseServer {
+
+  /**
+    * Basic command-line interface to start metabrowse-server.
+    *
+    * Examples: {{{
+    *
+    *   // browse multiple artifacts with no custom compiler flags
+    *   metabrowse-server org.scalameta:scalameta_2.12:4.0.0 org.typelevel:paiges_2.12:0.2.1
+    *
+    *   // browse artifact with custom compiler flags
+    *   metabrowse-server -Yrangepos -Xfatal-warning -- org.scalameta:scalameta_2.12:4.0.0
+    *
+    *   // browse artifact with macroparadise and kind-project plugins enabled
+    *   metabrowse-server macroparadise -- org.scalameta:scalameta_2.12:4.0.0
+    *
+    * }}}
+    *
+    * This basic interface exists primarily for local testing purposes, it's probably best
+    * to use a proper command-line parsing library down the road,
+    */
+  def main(arrayArgs: Array[String]): Unit = {
+    val args = arrayArgs.iterator.map {
+      case "macroparadise" => s"-Xplugin:$macroParadise"
+      case "kind-projector" => s"-Xplugin:$kindProjector"
+      case flag => flag
+    }.toList
+    val dash = args.indexOf("--")
+    val (scalacOptions, artifacts) = {
+      if (dash < 0) {
+        (Nil, args)
+      } else {
+        (args.slice(0, dash), args.slice(dash + 1, args.length))
+      }
+    }
+    val sourcepath = Sourcepath(artifacts)
+    val server = new MetabrowseServer(scalacOptions = scalacOptions)
+    val in = new Scanner(System.in)
+    server.start(sourcepath)
+    try {
+      println(
+        "Listening to http://localhost:4000/ (press enter to stop server)"
+      )
+      in.nextLine()
+    } catch {
+      case NonFatal(_) =>
+    } finally {
+      println("Stopping server...")
+      server.stop()
+    }
+  }
+
+  private def macroParadise: Path =
+    Sourcepath.coursierFetchCompilerPlugin(
+      s"org.scalamacros:paradise_${scalaFullVersion}:2.1.0"
+    )
+  private def kindProjector: Path =
+    Sourcepath.coursierFetchCompilerPlugin(
+      s"org.spire-math:kind-projector_${scalaBinaryVersion}:0.9.8"
+    )
+  private def scalaFullVersion: String =
+    scala.util.Properties.versionNumberString
+  private def scalaBinaryVersion: String =
+    scala.util.Properties.versionNumberString.split("\\.").take(2).mkString(".")
+}

--- a/metabrowse-server/src/main/scala/metabrowse/server/MetabrowseServer.scala
+++ b/metabrowse-server/src/main/scala/metabrowse/server/MetabrowseServer.scala
@@ -26,7 +26,7 @@ import scala.meta.inputs.Input
 import scala.meta.interactive.InteractiveSemanticdb
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.io.InputStreamIO
-import scala.meta.internal.mtags.Enrichments._
+import scala.meta.internal.mtags.MtagsEnrichments._
 import scala.meta.internal.mtags.Mtags
 import scala.meta.internal.mtags.OnDemandSymbolIndex
 import scala.meta.internal.semanticdb.TextDocuments

--- a/metabrowse-server/src/main/scala/metabrowse/server/Sourcepath.scala
+++ b/metabrowse-server/src/main/scala/metabrowse/server/Sourcepath.scala
@@ -1,0 +1,63 @@
+package metabrowse.server
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+  * A sourcepath contains `*.{class,java,scala}` files of a project.
+  *
+  * @param classpath the regular JVM classpath of this project, containing
+  *                  `*.class` files that can be used to compile the project.
+  *                  Must match the `-classpath` argument passed to the Scala
+  *                  compiler.
+  * @param sources the accompanying sources.jar files for this project that
+  *                are published under the "sources" classifier.
+  */
+case class Sourcepath(classpath: List[Path], sources: List[Path])
+
+object Sourcepath {
+
+  /** Use coursier to fetch the classpath and sources of an artifact.
+    *
+    * @param artifact the artifact name, for example
+    *                 - org.scala-lang:scala-library:2.12.7
+    *                 - org.scalameta:scalameta_2.12:4.0.0
+    */
+  def apply(artifacts: List[String]): Sourcepath = {
+    Sourcepath(
+      classpath = coursierFetch(artifacts),
+      sources = jdkSources().toList ++
+        coursierFetch(artifacts ++ List("--classifier", "sources"))
+    )
+  }
+  def apply(artifact: String): Sourcepath = {
+    Sourcepath(List(artifact))
+  }
+
+  /** The sources of the JDK, for example `java/lang/String.java` */
+  def jdkSources(): Option[Path] = {
+    for {
+      javaHome <- sys.props.get("java.home")
+      srcZip = Paths.get(javaHome).getParent.resolve("src.zip")
+      if Files.isRegularFile(srcZip)
+    } yield srcZip
+  }
+
+  private[metabrowse] def coursierFetchCompilerPlugin(
+      artifact: String
+  ): Path = {
+    coursierFetch(List("--intransitive", artifact)).headOption.getOrElse {
+      sys.error(artifact)
+    }
+  }
+  private[metabrowse] def coursierFetch(extra: List[String]): List[Path] = {
+    sys.process
+      .Process(List("coursier", "fetch") ++ extra)
+      .!!
+      .trim
+      .linesIterator
+      .map(jar => Paths.get(jar))
+      .toList
+  }
+}

--- a/metabrowse-tests/src/it/scala/metabrowse/tests/MetabrowseServerSuite.scala
+++ b/metabrowse-tests/src/it/scala/metabrowse/tests/MetabrowseServerSuite.scala
@@ -1,0 +1,64 @@
+package metabrowse.tests
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+import metabrowse.server.MetabrowseServer
+import metabrowse.server.Sourcepath
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.FunSuite
+import org.scalatest.selenium.Chrome
+import scala.meta.interactive.InteractiveSemanticdb
+
+class MetabrowseServerSuite
+    extends FunSuite
+    with Chrome
+    with BeforeAndAfterAll {
+  val server = new MetabrowseServer()
+  val sourcepath = Sourcepath("org.typelevel:paiges-core_2.12:0.2.1")
+  override def beforeAll(): Unit = {
+    server.start(sourcepath)
+  }
+  override def afterAll(): Unit = {
+    server.stop()
+    quit()
+  }
+
+  val host = "http://localhost:4000/#"
+  val DocScala = s"$host/org/typelevel/paiges/Doc.scala#L209C14-L209C19"
+  val ChunkScala = s"$host/org/typelevel/paiges/Chunk.scala#L5C24"
+
+  // See: https://github.com/SeleniumHQ/selenium/blob/master/rb/lib/selenium/webdriver/common/keys.rb
+  val F12 = "\ue03C"
+  val Command = "\ue03D"
+  def sleep(seconds: Int): Unit = {
+    Thread.sleep(TimeUnit.SECONDS.toMillis(seconds))
+  }
+
+  // NOTE(olafur): This is a first selenium test I ever write so it's quite hacky.
+  // This test likely fails in a CI environment (needs chrome installed) and also fails
+  // on non-macOS since it relies on the Mac-specific "Cmd" keyboard modifier.
+  test("goto definition") {
+    go to DocScala
+    assert(pageTitle == "Metabrowse")
+    className("mtk1")
+    sleep(10)
+    pressKeys(Command + F12)
+    sleep(5)
+    assert(currentUrl == ChunkScala)
+    goBack()
+    sleep(5)
+    assert(currentUrl == DocScala)
+  }
+
+  test("urlForSymbol") {
+    val g = InteractiveSemanticdb.newCompiler(
+      sourcepath.classpath.mkString(File.pathSeparator),
+      Nil
+    )
+    val some =
+      g.rootMirror.staticClass("scala.Some").info.member(g.TermName("isEmpty"))
+    val obtained = server.urlForSymbol(g)(some).get
+    g.askShutdown()
+    assert(obtained == "#/scala/Option.scala#L333C6")
+  }
+}

--- a/metabrowse-tests/src/test/scala/metabrowse/tests/BaseMetabrowseCliSuite.scala
+++ b/metabrowse-tests/src/test/scala/metabrowse/tests/BaseMetabrowseCliSuite.scala
@@ -12,7 +12,7 @@ import metabrowse.{schema => d}
 import metabrowse.MetabrowseEnrichments._
 import GeneratedSiteEnrichments._
 
-class BaseMetabrowseCliSuite
+abstract class BaseMetabrowseCliSuite
     extends FunSuite
     with BeforeAndAfterAll
     with DiffAssertions {

--- a/metabrowse-tests/src/test/scala/metabrowse/tests/MetabrowseCliSuite.scala
+++ b/metabrowse-tests/src/test/scala/metabrowse/tests/MetabrowseCliSuite.scala
@@ -254,7 +254,7 @@ class MetabrowseCliSuite extends BaseMetabrowseCliSuite {
     assert(Files.exists(workspacePath.toNIO))
     val workspace = d.Workspace.parseFromCompressedPath(workspacePath)
     assert(workspace.filenames.nonEmpty)
-    expectedFiles.lines.filter(_.trim.nonEmpty).foreach { file =>
+    expectedFiles.linesIterator.filter(_.trim.nonEmpty).foreach { file =>
       assert(workspace.filenames.contains(file.stripSuffix(".semanticdb.gz")))
     }
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,11 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "0.6.0")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")
+
 addSbtCoursier
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin-shaded" % "0.8.0"
-libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
+
+libraryDependencies ++= List(
+  "com.thesamet.scalapb" %% "compilerplugin-shaded" % "0.8.0",
+  "io.github.bonigarcia" % "webdrivermanager" % "3.0.0",
+  "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
+)


### PR DESCRIPTION
The metabrowse-cli module is great because it generates a static site can
be hosted by any static file server. However, if we control the server
then we can serve the SemanticDBs on-demand for any
classpath+sources.jar.

This commit implements a server that uses the same monaco/metabrowse
JavaScript client but serves SemanticDBs and symbol indexes on-demand.
This enables the server to start fast (a few seconds even for larger
classpaths) and does not requires the classpath/sources to be compiled
with SemanticDB beforehand.

To start the server and browse Scalameta sources with the
scalamacros:paradise compiler plugin enabled:
```
metabrowse-server macroparadise -- org.scalameta:scalameta_2.12:4.0.0
```

This commit implements basic selenium tests to check that it works as
expected. I have no experience whatsoever writing selenium tests so it's
quite hacky (Thread.sleep), but I think it's better than having no tests
at all.  For now, I am happy to not run the selenium tests in CI but
keep them around for manual local testing.

cc/ @alexarchambault 