### PR TITLE
Switch to scalameta 4.2.5, scala 2.12.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: scala
-scala: 2.12.10
+scala: 2.13.1
 jdk: oraclejdk8
 sudo: false
 dist: trusty
@@ -21,6 +21,9 @@ jobs:
       script: sbt ci-test
     - jdk: openjdk11
       env: TEST="sbt ci-test"
+      script: sbt ci-test
+    - env: TEST="sbt ci-test"
+      scala: 2.12.10
       script: sbt ci-test
     - env: TEST="sbt ci-test"
       scala: 2.11.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: scala
-scala: 2.12.7
+scala: 2.12.10
 jdk: oraclejdk8
 sudo: false
 dist: trusty

--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,9 @@ import scalajsbundler.util.JSON._
 import sbtcrossproject.{crossProject, CrossType}
 
 lazy val Version = new {
-  def scala212 = "2.12.7"
+  def scala212 = "2.12.10"
   def scala211 = "2.11.12"
-  def scalameta = "4.1.0"
+  def scalameta = "4.2.5"
 }
 
 inThisBuild(
@@ -76,7 +76,7 @@ lazy val server = project
       "io.undertow" % "undertow-core" % "2.0.27.Final",
       "org.slf4j" % "slf4j-api" % "1.8.0-beta4",
       "org.jboss.xnio" % "xnio-nio" % "3.7.5.Final",
-      "org.scalameta" % "interactive" % "4.1.4" cross CrossVersion.full,
+      "org.scalameta" % "semanticdb-scalac-core" % Version.scalameta cross CrossVersion.full,
       "org.scalameta" %% "mtags" % "0.4.4"
     )
   )
@@ -245,7 +245,7 @@ lazy val tests = project
         .value,
     libraryDependencies ++= List(
       "org.scalameta" %% "testkit" % Version.scalameta,
-      "org.scalameta" % "interactive" % Version.scalameta cross CrossVersion.full,
+      "org.scalameta" % "semanticdb-scalac-core" % Version.scalameta cross CrossVersion.full,
       "org.scalatest" %% "scalatest" % "3.0.6",
       "org.scalacheck" %% "scalacheck" % "1.14.0",
       "org.seleniumhq.selenium" % "selenium-java" % "3.141.59" % IntegrationTest,

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,7 @@ import scalajsbundler.util.JSON._
 import sbtcrossproject.{crossProject, CrossType}
 
 lazy val Version = new {
+  def scala213 = "2.13.1"
   def scala212 = "2.12.10"
   def scala211 = "2.11.12"
   def scalameta = "4.2.5"
@@ -31,8 +32,12 @@ inThisBuild(
         url("https://github.com/jonas")
       )
     ),
-    scalaVersion := Version.scala212,
-    crossScalaVersions := Seq(Version.scala212, Version.scala211),
+    scalaVersion := Version.scala213,
+    crossScalaVersions := Seq(
+      Version.scala213,
+      Version.scala212,
+      Version.scala211
+    ),
     scalacOptions := Seq(
       "-deprecation",
       "-encoding",
@@ -210,6 +215,7 @@ val sbtPlugin = project
   .enablePlugins(BuildInfoPlugin)
   .settings(
     name := "sbt-metabrowse",
+    scalaVersion := Version.scala212,
     crossScalaVersions := Seq(Version.scala212),
     publishLocal := publishLocal
       .dependsOn(publishLocal in coreJVM)

--- a/build.sbt
+++ b/build.sbt
@@ -260,7 +260,8 @@ lazy val tests = project
         classDirectory.in(example, Compile).value,
         classDirectory.in(example, Test).value
       )
-    )
+    ),
+    fork.in(Test) := true
   )
   .dependsOn(cli, server)
   .enablePlugins(BuildInfoPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val example = project
       "-Xplugin-require:semanticdb"
     ),
     libraryDependencies ++= List(
-      "org.scalatest" %% "scalatest" % "3.0.6" % Test,
+      "org.scalatest" %% "scalatest" % "3.0.8" % Test,
       "org.scalacheck" %% "scalacheck" % "1.14.0" % Test
     ),
     test := {} // no need to run paiges tests.
@@ -77,7 +77,7 @@ lazy val server = project
       "org.slf4j" % "slf4j-api" % "1.8.0-beta4",
       "org.jboss.xnio" % "xnio-nio" % "3.7.5.Final",
       "org.scalameta" % "semanticdb-scalac-core" % Version.scalameta cross CrossVersion.full,
-      "org.scalameta" %% "mtags" % "0.4.4"
+      ("org.scalameta" %% "mtags" % "0.7.6").cross(CrossVersion.full)
     )
   )
   .dependsOn(cli)
@@ -98,8 +98,8 @@ lazy val cli = project
     },
     libraryDependencies ++= List(
       "com.thesamet.scalapb" %% "scalapb-json4s" % "0.10.0",
-      "com.github.alexarchambault" %% "case-app" % "1.2.0",
-      "com.github.pathikrit" %% "better-files" % "3.7.1"
+      "com.github.alexarchambault" %% "case-app" % "2.0.0-M9",
+      "com.github.pathikrit" %% "better-files" % "3.8.0"
     ),
     resourceGenerators in Compile += Def.task {
       val zip = (resourceManaged in Compile).value / "metabrowse-assets.zip"
@@ -141,8 +141,8 @@ lazy val js = project
     ),
     webpackConfigFile := Some(baseDirectory.value / "webpack.config.js"),
     libraryDependencies ++= Seq(
-      "org.scala-js" %%% "scalajs-dom" % "0.9.6",
-      "org.scalatest" %%% "scalatest" % "3.0.6" % Test
+      "org.scala-js" %%% "scalajs-dom" % "0.9.7",
+      "org.scalatest" %%% "scalatest" % "3.0.8" % Test
     ),
     npmDevDependencies in Compile ++= Seq(
       "copy-webpack-plugin" -> "4.5.2",
@@ -246,7 +246,7 @@ lazy val tests = project
     libraryDependencies ++= List(
       "org.scalameta" %% "testkit" % Version.scalameta,
       "org.scalameta" % "semanticdb-scalac-core" % Version.scalameta cross CrossVersion.full,
-      "org.scalatest" %% "scalatest" % "3.0.6",
+      "org.scalatest" %% "scalatest" % "3.0.8",
       "org.scalacheck" %% "scalacheck" % "1.14.0",
       "org.seleniumhq.selenium" % "selenium-java" % "3.141.59" % IntegrationTest,
       "org.slf4j" % "slf4j-simple" % "1.8.0-beta4"

--- a/metabrowse-cli/src/main/scala/metabrowse/cli/MetabrowseCli.scala
+++ b/metabrowse-cli/src/main/scala/metabrowse/cli/MetabrowseCli.scala
@@ -46,7 +46,7 @@ case class MetabrowseOptions(
     @HelpMessage(
       "The output directory to generate the metabrowse site. (required)"
     )
-    target: Option[String] = None,
+    target: String,
     @HelpMessage(
       "The SemanticDB sourceroot used to compiled sources, must match the compiler option -P:semanticdb:sourceroot:<value>. " +
         "Defaults to the working directory if empty."
@@ -68,7 +68,7 @@ case class MetabrowseOptions(
     )
     cwd: Option[String] = None
 ) {
-  def targetPath: AbsolutePath = AbsolutePath(target.get)
+  def targetPath: AbsolutePath = AbsolutePath(target)
 }
 
 case class Target(target: AbsolutePath, onClose: () => Unit)
@@ -414,10 +414,6 @@ object MetabrowseCli extends CaseApp[MetabrowseOptions] {
 
   def run(options: MetabrowseOptions, remainingArgs: RemainingArgs): Unit = {
 
-    if (options.target.isEmpty) {
-      error(caseapp.core.Error.Other("--target is required"))
-    }
-
     if (options.cleanTargetFirst) {
       import better.files._
       val file = options.targetPath.toFile.toScala
@@ -429,6 +425,6 @@ object MetabrowseCli extends CaseApp[MetabrowseOptions] {
     }
     val runner = new CliRunner(classpath, options)
     runner.run()
-    println(options.target.get)
+    println(options.target)
   }
 }

--- a/metabrowse-cli/src/main/scala/metabrowse/cli/MetabrowseCli.scala
+++ b/metabrowse-cli/src/main/scala/metabrowse/cli/MetabrowseCli.scala
@@ -24,7 +24,6 @@ import java.util.function.{Function => JFunction}
 import scala.collection.parallel.mutable.ParArray
 import scala.util.control.NonFatal
 import caseapp._
-import caseapp.core.Messages
 import java.util.zip.GZIPOutputStream
 import scalapb.json4s.JsonFormat
 import metabrowse.schema
@@ -408,13 +407,15 @@ class CliRunner(classpath: Seq[AbsolutePath], options: MetabrowseOptions) {
 
 object MetabrowseCli extends CaseApp[MetabrowseOptions] {
 
-  override val messages: Messages[MetabrowseOptions] =
-    Messages[MetabrowseOptions].copy(optionsDesc = "[options] classpath")
+  override val messages: caseapp.core.help.Help[MetabrowseOptions] =
+    caseapp.core.help
+      .Help[MetabrowseOptions]
+      .copy(optionsDesc = "[options] classpath")
 
   def run(options: MetabrowseOptions, remainingArgs: RemainingArgs): Unit = {
 
     if (options.target.isEmpty) {
-      error("--target is required")
+      error(caseapp.core.Error.Other("--target is required"))
     }
 
     if (options.cleanTargetFirst) {
@@ -423,7 +424,7 @@ object MetabrowseCli extends CaseApp[MetabrowseOptions] {
       if (file.exists) file.delete()
     }
 
-    val classpath = remainingArgs.remainingArgs.flatMap { cp =>
+    val classpath = remainingArgs.all.flatMap { cp =>
       cp.split(File.pathSeparator).map(AbsolutePath(_))
     }
     val runner = new CliRunner(classpath, options)

--- a/metabrowse-cli/src/main/scala/metabrowse/cli/TermDisplay.scala
+++ b/metabrowse-cli/src/main/scala/metabrowse/cli/TermDisplay.scala
@@ -38,7 +38,7 @@ object Terminal {
       None
 
   implicit class Ansi(val output: Writer) extends AnyVal {
-    private def control(n: Int, c: Char) = output.write(s"\033[" + n + c)
+    private def control(n: Int, c: Char) = output.write("\u001b[" + n + c)
 
     /**
       * Move up `n` squares

--- a/metabrowse-js/src/test/scala/metabrowse/PakoSuite.scala
+++ b/metabrowse-js/src/test/scala/metabrowse/PakoSuite.scala
@@ -2,7 +2,6 @@ package metabrowse
 
 import metabrowse.schema.Workspace
 import org.scalatest.FunSuite
-import scala.meta.internal.io.JSModules
 import scala.meta.internal.io.PathIO
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSGlobal

--- a/metabrowse-server/src/main/scala/metabrowse/server/MetabrowseServer.scala
+++ b/metabrowse-server/src/main/scala/metabrowse/server/MetabrowseServer.scala
@@ -221,7 +221,7 @@ class MetabrowseServer(
           .foreach(path => filenames += path.toNIO.toString.stripPrefix("/"))
       }
     }
-    Workspace(filenames.result())
+    Workspace(filenames.result().toSeq)
   }
 
   private def getSemanticdb(filename: String): TextDocuments = {

--- a/metabrowse-tests/src/test/scala/metabrowse/tests/BaseMetabrowseCliSuite.scala
+++ b/metabrowse-tests/src/test/scala/metabrowse/tests/BaseMetabrowseCliSuite.scala
@@ -23,7 +23,7 @@ abstract class BaseMetabrowseCliSuite
     nonInteractive = true
   )
   def files: Seq[String] =
-    BuildInfo.exampleClassDirectory.map(_.getAbsolutePath)
+    BuildInfo.exampleClassDirectory.map(_.getAbsolutePath).toSeq
 
   def runCli(): Unit = MetabrowseCli.run(options, RemainingArgs(files, Nil))
 
@@ -41,9 +41,12 @@ abstract class BaseMetabrowseCliSuite
       val index = indexes.indexes.find(_.symbol == id).get
       // Sort ranges to ensure we assert against deterministic input.
       val indexNormalized = index.copy(
-        references = index.references.mapValues { ranges =>
-          ranges.copy(ranges = ranges.ranges.sortBy(_.startLine))
-        }
+        references = index.references
+          .mapValues { ranges =>
+            ranges.copy(ranges = ranges.ranges.sortBy(_.startLine))
+          }
+          .iterator
+          .toMap
       )
       val obtained = indexNormalized.toProtoString
       assertNoDiffOrPrintExpected(obtained, expected)

--- a/metabrowse-tests/src/test/scala/metabrowse/tests/BaseMetabrowseCliSuite.scala
+++ b/metabrowse-tests/src/test/scala/metabrowse/tests/BaseMetabrowseCliSuite.scala
@@ -18,7 +18,7 @@ abstract class BaseMetabrowseCliSuite
     with DiffAssertions {
   var out: AbsolutePath = _
   def options = MetabrowseOptions(
-    Some(out.toString()),
+    out.toString(),
     cleanTargetFirst = true,
     nonInteractive = true
   )

--- a/metabrowse-tests/src/test/scala/metabrowse/tests/JsonSuite.scala
+++ b/metabrowse-tests/src/test/scala/metabrowse/tests/JsonSuite.scala
@@ -1,5 +1,7 @@
 package metabrowse.tests
 
+import java.io.File
+import java.net.URLClassLoader
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import scala.meta.internal.semanticdb._
@@ -19,7 +21,20 @@ import org.scalatest.FunSuite
 import metabrowse.tests.GeneratedSiteEnrichments._
 
 class JsonSuite extends FunSuite with DiffAssertions with BeforeAndAfterAll {
-  val compiler: Global = InteractiveSemanticdb.newCompiler()
+
+  // patched version of https://github.com/scalameta/scalameta/blob/3413f84849aa5c5091d7cb2460ff36a8c20a34be/semanticdb/scalac/library/src/main/scala/scala/meta/interactive/InteractiveSemanticdb.scala#L124-L129
+  private def thisClasspath: String = this.getClass.getClassLoader match {
+    case url: URLClassLoader =>
+      url.getURLs.map(_.toURI.getPath).mkString(File.pathSeparator)
+    case cl
+        if cl.getClass.getName == "jdk.internal.loader.ClassLoaders$AppClassLoader" =>
+      // Required with JDK-11
+      sys.props.getOrElse("java.class.path", "")
+    case els =>
+      throw new IllegalStateException(s"Expected URLClassloader, got $els")
+  }
+
+  val compiler: Global = InteractiveSemanticdb.newCompiler(thisClasspath, Nil)
   override def afterAll(): Unit = compiler.askShutdown()
   test(".semanticdb.json") {
     val doc = InteractiveSemanticdb.toTextDocument(

--- a/metabrowse-tests/src/test/scala/metabrowse/tests/JsonSuite.scala
+++ b/metabrowse-tests/src/test/scala/metabrowse/tests/JsonSuite.scala
@@ -53,7 +53,7 @@ class JsonSuite extends FunSuite with DiffAssertions with BeforeAndAfterAll {
     val out = Files.createTempDirectory("metabrowse")
     Files.write(jsonFile, dbJson.getBytes(StandardCharsets.UTF_8))
     MetabrowseCli.run(
-      MetabrowseOptions(target = Some(out.toString)),
+      MetabrowseOptions(target = out.toString),
       RemainingArgs(jsonFile.toString :: Nil, Nil)
     )
     val symbols = FileIO

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.3.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,8 +7,6 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "0.6.0")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.2")
 
-addSbtCoursier
-
 libraryDependencies ++= List(
   "io.github.bonigarcia" % "webdrivermanager" % "3.6.1",
   "com.thesamet.scalapb" %% "compilerplugin-shaded" % "0.9.4",

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.1.0-M7")

--- a/sbt-metabrowse/src/sbt-test/metabrowse/hello-world/build.sbt
+++ b/sbt-metabrowse/src/sbt-test/metabrowse/hello-world/build.sbt
@@ -2,7 +2,7 @@ name := "test"
 enablePlugins(MetabrowsePlugin)
 scalaVersion := _root_.metabrowse.sbt.BuildInfo.scalaVersion
 metabrowseSettings // enable semanticdb-scalac
-libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.3" % Test
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % Test
 
 def assertExists(file: File, message: String) =
   assert(file.exists, message)


### PR DESCRIPTION
So that more scala versions are supported down the line ([changes in scalameta](https://github.com/scalameta/scalameta/commit/d32204c8f61111115c44003ee81df9e5545e2244) prevent metabrowse to work fine with e.g. scala `2.12.10`).