### PR TITLE
Back to scalameta 4.8.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,11 @@ lazy val Version = new {
   )
   def scala213 = scala213Versions.last
   def scala212 = scala212Versions.last
-  def scalameta = "4.8.11"
+
+  // Important: this should be the exact same version as the one mtags pulls, as mtags uses some scalameta internal APIs,
+  // and binary compatibility of these APIs isn't guaranteed.
+  // Get this version with a command like 'cs resolve org.scalameta:mtags_2.13.12:1.0.1 | grep org.scalameta:scalameta'
+  def scalameta = "4.8.3"
 }
 
 inThisBuild(


### PR DESCRIPTION
Which is the version pulled by mtags. This ensures there's no binary incompatibility for mtags, which uses some scalameta internal APIs, whose binary compatibility isn't guaranteed.