### PR TITLE
Don't limit scala steward to a monthly frequency

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,4 +1,3 @@
-pullRequests.frequency = "@monthly"
 updates.ignore = [
   { groupId = "org.scala-js" }
   { groupId = "io.undertow", artifactId = "undertow-core" }


### PR DESCRIPTION
Seems I'm the only person merging things on this repo. I'd rather have PRs opened for updates as early as possible, to fasten updates when these are needed (usually, AFAIC, when supporting newer Scala versions in [Almond](https://github.com/almond-sh/almond)).